### PR TITLE
Make xml file configurable at runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ bin
 gen
 
 .lvimrc
+.vscode-cpptools

--- a/Makefile
+++ b/Makefile
@@ -54,12 +54,12 @@ test-apply: \
 	bin/AddUBDTBranchRun2 \
 		-i samples/Jpsi--21_02_05--pidcalib--data_turbo--2016--mu--Mu_nopt-subset.root \
 		-o gen/pidcalib_old.root \
-		-p probe -x weights/weights_run2_no_cut_ubdt.xml -b UBDT \
+		-p probe -x weights -w weights_run2_no_cut_ubdt.xml -b UBDT \
 		-t "Jpsinopt_MuMTuple/DecayTree","Jpsinopt_MuPTuple/DecayTree"
 	bin/AddUBDTBranchRun2PidCalib \
 		-i samples/Jpsi--21_11_30--pidcalib--data_turbo--2016--mu--Mu_nopt-subset.root \
 		-o gen/pidcalib_new.root \
-		-p probe -x weights/weights_run2_no_cut_ubdt.xml -b UBDT \
+		-p probe -x weights -w weights_run2_no_cut_ubdt.xml -b UBDT \
 		-t "Jpsinopt_MuMTuple/DecayTree","Jpsinopt_MuPTuple/DecayTree"
 	plotbr \
 		-o ./gen/mu_bdt_mu_MuM_comp_norm.png \

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ VPATH	:=	test:src:$(VPATH)
 COMPILER	:=	$(shell root-config --cxx)
 CXXFLAGS	:=	$(shell root-config --cflags)
 LINKFLAGS	:=	$(shell root-config --libs)
-ADDCXXFLAGS	:=	-g -O1
+ADDCXXFLAGS_OPT	:=	-O3
+ADDCXXFLAGS_DBG	:=	-g -Og
 ADDLINKFLAGS	:=	-lTreePlayer -lMinuit -lFoam -lXMLIO -lTMVA
 
 CASTELAO_VERSION=Castelao-v3r4
@@ -120,7 +121,7 @@ test-merge-ntp:
 ####################
 
 %.dbg: %.cpp
-	$(COMPILER) $(CXXFLAGS) $(ADDCXXFLAGS) -o $(BINPATH)/$@ $< $(LINKFLAGS) $(ADDLINKFLAGS)
+	$(COMPILER) $(CXXFLAGS) $(ADDCXXFLAGS_DBG) -o $(BINPATH)/$@ $< $(LINKFLAGS) $(ADDLINKFLAGS)
 
 %: %.cpp
-	$(COMPILER) $(CXXFLAGS) -o $(BINPATH)/$@ $< $(LINKFLAGS) $(ADDLINKFLAGS)
+	$(COMPILER) $(CXXFLAGS) $(ADDCXXFLAGS_OPT) -o $(BINPATH)/$@ $< $(LINKFLAGS) $(ADDLINKFLAGS)

--- a/MuonBDTPid.code-workspace
+++ b/MuonBDTPid.code-workspace
@@ -1,0 +1,113 @@
+{
+    "extensions": {
+        "recommendations": [
+            "albertopdrf.root-file-viewer",
+            "eamodio.gitlens",
+            "eeyore.yapf",
+            "ms-python.flake8",
+            "ms-python.python",
+            "ms-python.vscode-pylance",
+            "ms-vscode.cpptools",
+            "ms-vscode.makefile-tools",
+            "davidanson.vscode-markdownlint",
+            "streetsidesoftware.code-spell-checker",
+            "bbenoist.Nix"
+        ]
+    },
+    "folders": [
+        {
+            "path": "./"
+        }
+    ],
+    "settings": {
+        "C_Cpp.configurationWarnings": "disabled",
+        "C_Cpp.default.browse.databaseFilename": "${workspaceFolder}/.vscode-cpptools/browse.VC.db",
+        "C_Cpp.default.browse.path": [],
+        "C_Cpp.default.cStandard": "c11",
+        "C_Cpp.default.compileCommands": "",
+        "C_Cpp.default.compilerPath": "/usr/bin/g++",
+        "C_Cpp.default.configurationProvider": "nonexistent.extension",
+        "C_Cpp.default.cppStandard": "c++17",
+        "C_Cpp.default.defines": [],
+        "C_Cpp.default.includePath": [
+            "${workspaceFolder}/include/",
+            // TODO Get include paths from Nix store automatically.
+            // They are currently hardcoded and since some appear multiple times in the
+            // store (such as boost-1.75.0-dev), I'm not sure which one is the correct
+            // (they look equivalent, but they have different hashes so there is some difference).
+            "/nix/store/dlwb9al8d40rllzbhfbzj28jips65lr6-root-6.32.16/include/*",
+            "/nix/store/rbvd1cq9gy7vbkds7v2w968vmrl5a9vd-roounfold-2.1/include/",
+            "/nix/store/3zvgb0wgvbjal65sb4mz50r0dzsgsdn4-libyaml-cpp-0.6.3/include/",
+            "/nix/store/hnawcrf4iigsk47pxz0bg5mg1w1szfir-boost-1.75.0-dev/include",
+            "/nix/store/bd28hkx3zkzhfwjj5l91h7l4wqx4qmaf-cxxopts/include"
+        ],
+        "C_Cpp.default.intelliSenseMode": "gcc-x64",
+        "C_Cpp.files.exclude": {
+            "**/.vscode": true,
+            "**/.vscode-cpptools/": true,
+            "/usr": true
+        },
+        "C_Cpp.intelliSenseCachePath": "${workspaceFolder}/.vscode-cpptools/cache",
+        "C_Cpp.intelliSenseCacheSize": 0,
+        "C_Cpp.workspaceParsingPriority": "low",
+        "[python]": {
+            "editor.defaultFormatter": "eeyore.yapf"
+        },
+        "cSpell.diagnosticLevel": "Hint",
+        "cSpell.enabledLanguageIds": [
+            "c",
+            "cpp",
+            "markdown",
+            "python",
+            "restructuredtext",
+            "text"
+        ],
+        "cSpell.language": "en,en-GB",
+        "cSpell.languageSettings": [
+            {
+                "includeRegExpList": [
+                    "/#.*/",
+                    "/('''|\"\"\")[^\\1]+?\\1/g",
+                    "strings"
+                ],
+                "languageId": "python"
+            },
+            {
+                "allowCompoundWords": false,
+                "ignoreRegExpList": [
+                    "/#include.*/"
+                ],
+                "includeRegExpList": [
+                    "CStyleComment",
+                    "string"
+                ],
+                "languageId": "cpp,c"
+            }
+        ],
+        "files.associations": {
+            "*.C": "cpp",
+            "*.icpp": "cpp",
+            "cmath": "cpp",
+            "iostream": "cpp",
+            "ostream": "cpp",
+            "chrono": "cpp",
+            "functional": "cpp",
+            "vector": "cpp",
+            "thread": "cpp",
+            "new": "cpp",
+            "unordered_map": "cpp",
+            "string": "cpp",
+            "array": "cpp",
+            "type_traits": "cpp",
+            "memory": "cpp"
+        },
+        "files.trimTrailingWhitespace": true,
+        "flake8.args": [
+            "--select=F,E71,E9,W1,W6"
+        ],
+        "python.defaultInterpreterPath": "/usr/bin/python3",
+        "python.languageServer": "Pylance",
+        "remote.downloadExtensionsLocally": true,
+        "window.title": "${dirty}${activeEditorShort}${separator}${rootPath}"
+    }
+}

--- a/README.md
+++ b/README.md
@@ -7,6 +7,24 @@ Below we list some related links:
 - PIDCalib package [twiki](https://twiki.cern.ch/twiki/bin/view/LHCb/PIDCalibPackage)
 - PIDCalib sample modes and cuts [option file](https://gitlab.cern.ch/lhcb/Castelao/-/blob/master/PIDCalib/PidCalibProduction/options/Run-2/makeTuples.py)
 
+## `git-annex` setup
+
+If you haven't cloned this project, do these steps first:
+
+```shell
+git clone git@github.com:umd-lhcb/MuonBDTPid
+cd MuonBDTPid
+```
+
+Now add our `git-annex` repository:
+
+```shell
+git remote add julian git@lhcb.physics.umd.edu:MuonBDTPid
+git annex init --version=7
+# Before proceeding, make sure you do not have uncommitted/unstashed changes in the repo,
+# because 'git annex sync' commits and then pushes everything
+git annex sync
+```
 
 ## Add Greg's run 2 Mu BDT branch
 

--- a/nix/AddUBDTBranch/default.nix
+++ b/nix/AddUBDTBranch/default.nix
@@ -16,6 +16,7 @@ stdenv.mkDerivation {
     mkdir -p $out/weights
     cp bin/AddUBDTBranchRun2 $out/bin
     cp bin/AddUBDTBranchRun2PidCalib $out/bin
-    cp weights/weights_run2_no_cut_ubdt.xml $out/weights/ubdt_run2.xml
+    cp weights/weights_run2_no_cut_ubdt.xml $out/weights/ubdt_run2_no_cut.xml
+    cp weights/weights_run2_all_cuts_ubdt.xml $out/weights/ubdt_run2_all_cuts.xml
   '';
 }

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -15,13 +15,13 @@ final: prev:
     unset LD_LIBRARY_PATH
     unset DYLD_LIBRARY_PATH
 
-    exec ${final.AddUBDTBranch}/bin/AddUBDTBranchRun2 $@ -x ${final.AddUBDTBranch}/weights/ubdt_run2.xml
+    exec ${final.AddUBDTBranch}/bin/AddUBDTBranchRun2 $@ -w ${final.AddUBDTBranch}/weights
   '';
 
   AddUBDTBranchPidCalibWrapped = prev.writeScriptBin "AddUBDTBranchPidCalib" ''
     unset LD_LIBRARY_PATH
     unset DYLD_LIBRARY_PATH
 
-    exec ${final.AddUBDTBranch}/bin/AddUBDTBranchRun2PidCalib $@ -x ${final.AddUBDTBranch}/weights/ubdt_run2.xml
+    exec ${final.AddUBDTBranch}/bin/AddUBDTBranchRun2PidCalib $@ -w ${final.AddUBDTBranch}/weights
   '';
 }

--- a/src/AddUBDTBranchRun2.cpp
+++ b/src/AddUBDTBranchRun2.cpp
@@ -305,6 +305,7 @@ int main(int argc, char **argv) {
     ("i,input", "input ntuple", cxxopts::value<string>())
     ("o,output", "output ntuple", cxxopts::value<string>())
     ("x,xml", "BDT XML export file", cxxopts::value<string>())
+    ("w,xmlPath", "BDT XML export file", cxxopts::value<string>())
     ("b,ubdtBrName", "UBDT branch name",
      cxxopts::value<string>()->default_value("bdt_mu"))
     ("p,particle", "particle name",
@@ -321,10 +322,13 @@ int main(int argc, char **argv) {
 
   auto inputFilename  = TString(parsedArgs["input"].as<string>());
   auto outputFilename = TString(parsedArgs["output"].as<string>());
-  auto xmlFilename    = TString(parsedArgs["xml"].as<string>());
+  auto xmlFile        = TString(parsedArgs["xml"].as<string>());
+  auto xmlPath        = TString(parsedArgs["xmlPath"].as<string>());
   auto particle       = TString(parsedArgs["particle"].as<string>());
   auto ubdtBrName     = TString(parsedArgs["ubdtBrName"].as<string>());
   auto trees          = parsedArgs["trees"].as<vector<string>>();
+
+  TString xmlFilename = xmlPath + "/" + xmlFile;
 
   auto ntpIn  = new TFile(inputFilename, "read");
   auto ntpOut = new TFile(outputFilename, "recreate");


### PR DESCRIPTION
The main modification here is to enable us to pick the xml file when running this tool from lhcb-ntuple-gen (check workflow_ubdt in https://github.com/umd-lhcb/lhcb-ntuples-gen/blob/master/workflows/rdx.py).
Now, only the location of the xmls is "hardcoded" in the `AddUBDTBranch` command defined in [nix/overlay.nix](https://github.com/umd-lhcb/MuonBDTPid/blob/master/nix/overlay.nix) (it's not really hardcoded; it's pickup up from the nix environment), and the name of the xml file **must** be passed as an argument e.g. `AddUBDTBranch -x ubdt_run2_no_cut.xml`.
Use `-x ubdt_run2_all_cuts.xml` for the Run 1 RDx training (which assumes a DLLmu>2 cut) or `-x ubdt_run2_no_cut.xml` for the Run 2 Angular Analysis training, which does not assume the DLLmu cut.